### PR TITLE
Support "EEP 37: Funs with names" introduced in Erlang/OTP 17.0

### DIFF
--- a/src/cut.erl
+++ b/src/cut.erl
@@ -328,6 +328,9 @@ expr({'fun', Line, Body}) ->
         {function, M, F, A} -> %% R10B-6: fun M:F/A.
             {'fun', Line, {function, M, F, A}}
     end;
+expr({named_fun, Line, Name, Cs0}) -> % OTP 17.0: EEP 37: Funs with names
+    Cs1 = fun_clauses(Cs0),
+    {named_fun, Line, Name, Cs1};
 expr({call, Line, F0, As0}) ->
     %% N.B. If F an atom then call to local function or BIF, if F a
     %% remote structure (see below) then call to other module,

--- a/src/do.erl
+++ b/src/do.erl
@@ -254,6 +254,9 @@ expr({'fun', Line, Body}, MonadStack) ->
         {function, M, F, A} -> %% R10B-6: fun M:F/A.
             {'fun', Line, {function, M, F, A}}
     end;
+expr({named_fun, Line, Name, Cs0}, MonadStack) -> % OTP 17.0: EEP 37: Funs with names
+    Cs1 = fun_clauses(Cs0, MonadStack),
+    {named_fun, Line, Name, Cs1};
 %%  do syntax detection:
 expr({call, Line, {atom, _Line1, do},
       [{lc, _Line2, {AtomOrVar, _Line3, _MonadModule} = Monad, Qs}]},

--- a/test/src/test_cut.erl
+++ b/test/src/test_cut.erl
@@ -126,6 +126,14 @@ test_cut_comprehensions() ->
     [{3,4,5}, {4,3,5}, {6,8,10}, {8,6,10}] =
         lists:usort(F1(lists:seq(1,10), lists:seq(1,10), lists:seq(1,10))).
 
+test_cut_named_fun() ->
+    Add  = _ + _,
+    Fib  = fun Self (0) -> 1;
+               Self (1) -> 1;
+               Self (N) -> (Add(_, _))(N, Self(N-1))
+           end,
+    true = (Fib(_))(10) =:= 55.
+
 test() ->
     test:test([{?MODULE, [test_cut,
                           test_cut_nested,
@@ -137,5 +145,6 @@ test() ->
                           test_cut_binary,
                           test_cut_list,
                           test_cut_case,
-                          test_cut_comprehensions]}],
+                          test_cut_comprehensions,
+                          test_cut_named_fun]}],
               [report, {name, ?MODULE}]).

--- a/test/src/test_do.erl
+++ b/test/src/test_do.erl
@@ -187,6 +187,14 @@ test_let_escapes() ->
     M3 = do([maybe_m || return((_A = 7) - 2)]),
     _A = 6.
 
+test_named_fun() ->
+    Fib  = fun Self (0) -> identity_m:return(1);
+               Self (1) -> identity_m:return(1);
+               Self (N) -> do([identity_m || M <- Self(N-1),
+                                             return(N+M)])
+           end,
+    true = Fib(10) =:= 55.
+
 test() ->
     test:test([{?MODULE, [test_sequence,
                           test_join,
@@ -197,5 +205,6 @@ test() ->
                           test_error_t_list,
                           test_let_match,
                           test_let_first,
-                          test_let_escapes]}],
+                          test_let_escapes,
+                          test_nemd_fun]}],
               [report, {name, ?MODULE}]).


### PR DESCRIPTION
The codebase doesn't compile on OTP 17.0 unless the pmod issue is somehow worked around though.

For named funs, see http://www.erlang.org/eeps/eep-0037.html