### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 Erlando is a set of syntax extensions for Erlang. Currently it
 consists of three syntax extensions, all of which take the form of
-[parse-transformers](http://www.erlang.org/doc/man/erl_id_trans.html).
+[parse-transformers](https://www.erlang.org/doc/man/erl_id_trans.html).
 
 * **Cut**: This adds support for *cut*s to Erlang. These are
   inspired by the
-  [Scheme form of cuts](http://srfi.schemers.org/srfi-26/srfi-26.html). *Cut*s
+  [Scheme form of cuts](https://srfi.schemers.org/srfi-26/srfi-26.html). *Cut*s
   can be thought of as a light-weight form of abstraction, with
   similarities to partial application (or currying).
 
 * **Do**: This adds support for *do*-syntax and monads to
-  Erlang. These are heavily inspired by [Haskell](http://haskell.org),
+  Erlang. These are heavily inspired by [Haskell](https://haskell.org),
   and the monads and libraries are near-mechanical translations from
   the Haskell GHC libraries.
 
@@ -223,7 +223,7 @@ you're just defining another list element.
 
 
 See
-[test_cut.erl](http://hg.rabbitmq.com/erlando/file/default/test/src/test_cut.erl)
+[test_cut.erl](https://hg.rabbitmq.com/erlando/file/default/test/src/test_cut.erl)
 for more examples, including the use of *cut*s in list comprehensions and
 binary construction.
 
@@ -531,7 +531,7 @@ it to (and collect it from) the functions we wish to run.
 
 > Our implementation of monad-transformers (like State) uses a "hidden feature"
 of the Erlang distribution called *parameterized modules*. These are
-described in [Parameterized Modules in Erlang](http://ftp.sunet.se/pub/lang/erlang/workshop/2003/paper/p29-carlsson.pdf).
+described in [Parameterized Modules in Erlang](https://ftp.sunet.se/pub/lang/erlang/workshop/2003/paper/p29-carlsson.pdf).
 
 The State-transform can be applied to any monad. If we apply it to the
 Identity-monad then we get what we're looking for. The key extra
@@ -600,7 +600,7 @@ For cosmetic reasons, it is sometimes desirable to import a remote
 function into the current module's namespace. This eliminates the need
 to continuously prefix calls to that function with its module
 name. Erlang can already do this by using the
-[`-import` attribute](http://www.erlang.org/doc/reference_manual/modules.html).
+[`-import` attribute](https://www.erlang.org/doc/reference_manual/modules.html).
 However, this always uses the same function name locally as remotely
 which can either lead to misleading function names or even
 collisions. Consider, for example, wishing to import `length`

--- a/src/cut.erl
+++ b/src/cut.erl
@@ -1,7 +1,7 @@
 %% This file is a copy of erl_id_trans.erl from the R14B02 Erlang/OTP
 %% distribution, with modifications to make it implement Scheme
 %% Notation for Specializing Parameters without Currying
-%% (http://srfi.schemers.org/srfi-26/srfi-26.html).
+%% (https://srfi.schemers.org/srfi-26/srfi-26.html).
 
 %% All modifications are (C) 2011-2013 VMware, Inc.
 
@@ -10,7 +10,7 @@
 %% Version 1.1, (the "License"); you may not use this file except in
 %% compliance with the License. You should have received a copy of the
 %% Erlang Public License along with this software. If not, it can be
-%% retrieved via the world wide web at http://www.erlang.org/.
+%% retrieved via the world wide web at https://www.erlang.org/.
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/do.erl
+++ b/src/do.erl
@@ -9,7 +9,7 @@
 %% Version 1.1, (the "License"); you may not use this file except in
 %% compliance with the License. You should have received a copy of the
 %% Erlang Public License along with this software. If not, it can be
-%% retrieved via the world wide web at http://www.erlang.org/.
+%% retrieved via the world wide web at https://www.erlang.org/.
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/error_m.erl
+++ b/src/error_m.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/error_t.erl
+++ b/src/error_t.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
@@ -49,7 +49,7 @@ return(X , {?MODULE, M}) -> M:return({ok, X}).
 %%     fail msg = ErrorT $ return (Left (strMsg msg))
 %% from the instance (Monad m, Error e) => Monad (ErrorT e m)
 %%
-%% http://hackage.haskell.org/packages/archive/mtl/1.1.0.2/doc/html/src/Control-Monad-Error.html#ErrorT
+%% https://hackage.haskell.org/packages/archive/mtl/1.1.0.2/doc/html/src/Control-Monad-Error.html#ErrorT
 %%
 %% I.e. note that calling fail on the outer monad is not a failure of
 %% the inner monad: it is success of the inner monad, but the failure

--- a/src/identity_m.erl
+++ b/src/identity_m.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/import_as.erl
+++ b/src/import_as.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/list_m.erl
+++ b/src/list_m.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/maybe_m.erl
+++ b/src/maybe_m.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/monad.erl
+++ b/src/monad.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/monad_plus.erl
+++ b/src/monad_plus.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/monad_trans.erl
+++ b/src/monad_trans.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/omega_m.erl
+++ b/src/omega_m.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
@@ -17,7 +17,7 @@
 %% This is the Omega monad which is like the list monad, but does not
 %% depth first, and not breadth first traversal. This implementation
 %% is based on Luke Palmer's Control.Monad.Omega module for Haskell
-%% (http://hackage.haskell.org/packages/archive/control-monad-omega/latest/doc/html/Control-Monad-Omega.html). As
+%% (https://hackage.haskell.org/packages/archive/control-monad-omega/latest/doc/html/Control-Monad-Omega.html). As
 %% the documentation there states:
 %%
 %%    Warning: Omega is only a monad when the results are interpreted

--- a/src/state_t.erl
+++ b/src/state_t.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/src/test.erl
+++ b/src/test.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/test/erlando_test.erl
+++ b/test/erlando_test.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/test/src/test_cut.erl
+++ b/test/src/test_cut.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/test/src/test_do.erl
+++ b/test/src/test_do.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/test/src/test_import_as.erl
+++ b/test/src/test_import_as.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://hg.rabbitmq.com/erlando/file/default/test/src/test_cut.erl (UnknownHostException) with 1 occurrences migrated to:  
  https://hg.rabbitmq.com/erlando/file/default/test/src/test_cut.erl ([https](https://hg.rabbitmq.com/erlando/file/default/test/src/test_cut.erl) result UnknownHostException).
* http://ftp.sunet.se/pub/lang/erlang/workshop/2003/paper/p29-carlsson.pdf (404) with 1 occurrences migrated to:  
  https://ftp.sunet.se/pub/lang/erlang/workshop/2003/paper/p29-carlsson.pdf ([https](https://ftp.sunet.se/pub/lang/erlang/workshop/2003/paper/p29-carlsson.pdf) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://srfi.schemers.org/srfi-26/srfi-26.html with 2 occurrences migrated to:  
  https://srfi.schemers.org/srfi-26/srfi-26.html ([https](https://srfi.schemers.org/srfi-26/srfi-26.html) result 200).
* http://www.erlang.org/ with 2 occurrences migrated to:  
  https://www.erlang.org/ ([https](https://www.erlang.org/) result 200).
* http://hackage.haskell.org/packages/archive/control-monad-omega/latest/doc/html/Control-Monad-Omega.html with 1 occurrences migrated to:  
  https://hackage.haskell.org/packages/archive/control-monad-omega/latest/doc/html/Control-Monad-Omega.html ([https](https://hackage.haskell.org/packages/archive/control-monad-omega/latest/doc/html/Control-Monad-Omega.html) result 301).
* http://hackage.haskell.org/packages/archive/mtl/1.1.0.2/doc/html/src/Control-Monad-Error.html with 1 occurrences migrated to:  
  https://hackage.haskell.org/packages/archive/mtl/1.1.0.2/doc/html/src/Control-Monad-Error.html ([https](https://hackage.haskell.org/packages/archive/mtl/1.1.0.2/doc/html/src/Control-Monad-Error.html) result 301).
* http://haskell.org with 1 occurrences migrated to:  
  https://haskell.org ([https](https://haskell.org) result 301).
* http://www.erlang.org/doc/man/erl_id_trans.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/erl_id_trans.html ([https](https://www.erlang.org/doc/man/erl_id_trans.html) result 301).
* http://www.erlang.org/doc/reference_manual/modules.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/reference_manual/modules.html ([https](https://www.erlang.org/doc/reference_manual/modules.html) result 301).
* http://www.mozilla.org/MPL/ with 16 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).